### PR TITLE
adpative radius search based on range

### DIFF
--- a/include/laser_filters/radius_search_filter.h
+++ b/include/laser_filters/radius_search_filter.h
@@ -65,7 +65,7 @@ class RadiusSearchFilter : public filters::FilterBase<sensor_msgs::LaserScan>
   /*
    * @brief The distance to be neighbor
    */
-  double threshold_radius_;
+  double threshold_ratio_;
 
   RadiusSearchFilter();
 

--- a/src/radius_search_filter.cpp
+++ b/src/radius_search_filter.cpp
@@ -9,8 +9,9 @@
  */
 
 #include <set>
-#include "laser_filters/radius_search_filter.h"
+#include <math.h>
 #include <ros/ros.h>
+#include "laser_filters/radius_search_filter.h"
 
 laser_filters::RadiusSearchFilter::RadiusSearchFilter(){
 }
@@ -70,7 +71,9 @@ bool laser_filters::RadiusSearchFilter::update(
         continue;
       }
 
-      if(fabs(input_scan.ranges[i]- input_scan.ranges[neighbor_index]) <= cur_threshold)
+      double cur_dist_sq = (input_scan.ranges[i] * input_scan.ranges[i]) + (input_scan.ranges[neighbor_index] * input_scan.ranges[neighbor_index]) + 2 * input_scan.ranges[i] * input_scan.ranges[neighbor_index] * cos((i-neighbor_index) * input_scan.angle_increment);
+
+      if( cur_dist_sq <= cur_threshold * cur_threshold)
       {
         counter++;
       }

--- a/src/radius_search_filter.cpp
+++ b/src/radius_search_filter.cpp
@@ -23,12 +23,12 @@ bool laser_filters::RadiusSearchFilter::configure()
   // Setup default values
   neighbor_num_ = 3;
   threshold_num_ = 3;
-  threshold_radius_ = 0.20;
+  threshold_ratio_ = 0.20;
 
   // launch values from parameter server
   getParam("neighbor_number", neighbor_num_);
   getParam("threshold_number", threshold_num_);
-  getParam("threshold_radius",  threshold_radius_);
+  getParam("threshold_ratio",  threshold_ratio_);
 
   return true;
 }
@@ -52,6 +52,11 @@ bool laser_filters::RadiusSearchFilter::update(
     }
 
     int counter = 0;
+
+    // adaptive threshold based on input_scan range value
+    // the further the point, the larger the radius search is set
+    double cur_threshold = ((int)(input_scan.ranges[i]) + 1) * threshold_ratio_;
+
     // for each point, traverse its neighbors
     for(int j= -neighbor_num_; j< neighbor_num_ + 1; j++)
     {
@@ -65,7 +70,7 @@ bool laser_filters::RadiusSearchFilter::update(
         continue;
       }
 
-      if(fabs(input_scan.ranges[i]- input_scan.ranges[neighbor_index]) <= threshold_radius_)
+      if(fabs(input_scan.ranges[i]- input_scan.ranges[neighbor_index]) <= cur_threshold)
       {
         counter++;
       }

--- a/test/test_scan_filter_chain.yaml
+++ b/test/test_scan_filter_chain.yaml
@@ -42,3 +42,11 @@ array_filter_chain:
           params:
             number_of_observations: 3
 
+radius_filter_chain:
+  - type: RadiusSearchFilter
+    name: radius_search
+    params:
+      neighbor_number: 3
+      threshold_number: 2
+      threshold_ratio: 0.1
+


### PR DESCRIPTION
Make radius search adaptive to range value. namely, the further the laser point, the larger the radius to consider other points as neighbors.