### PR TITLE
Hotfix/lidar reflection tests (PERCEPTION-1898)

### DIFF
--- a/include/laser_filters/scan_validator.h
+++ b/include/laser_filters/scan_validator.h
@@ -93,11 +93,6 @@ class ScanValidator : public filters::FilterBase<sensor_msgs::LaserScan>
    */
   bool has_checked_laser_config_;
 
-  /*
-   * @brief Laserscan configuration
-   */
-  std::string frame_id_;
-
   double angle_min_;
 
   double angle_max_;

--- a/include/laser_filters/scan_validator.h
+++ b/include/laser_filters/scan_validator.h
@@ -71,12 +71,12 @@ class ScanValidator : public filters::FilterBase<sensor_msgs::LaserScan>
   /*
    * @brief occlusion percentage to determine a false laserscan
    */
-  double occlusion_threshold_;
+  double lidar_occlusion_threshold_;
 
   /*
-   * @brief zero-value percentage for possible false case
+   * @brief invalid value percentage for warning about low-quality scans
    */
-  double zero_threshold_;
+  double lidar_invalid_threshold_;
 
   /*
    * @brief Contour for the robot lidar shroud

--- a/src/scan_validator.cpp
+++ b/src/scan_validator.cpp
@@ -74,10 +74,9 @@ bool laser_filters::ScanValidator::update(
       zero_count += 1;
       continue;
     }
-    // Counts for the reading is NaN or smaller than contour range
+    // Counts for the readings smaller than contour range
     // Make the contour slightly smaller to avoid false positive case
-    if(std::isnan(input_scan.ranges[i]) ||
-       input_scan.ranges[i] < (contour_[i] - contour_tolerance_))
+    if(input_scan.ranges[i] < (contour_[i] - contour_tolerance_)
     {
       occlusion_count += 1;
     }

--- a/src/scan_validator.cpp
+++ b/src/scan_validator.cpp
@@ -76,7 +76,7 @@ bool laser_filters::ScanValidator::update(
     }
     // Counts for the readings smaller than contour range
     // Make the contour slightly smaller to avoid false positive case
-    if(input_scan.ranges[i] < (contour_[i] - contour_tolerance_)
+    if(input_scan.ranges[i] < (contour_[i] - contour_tolerance_))
     {
       occlusion_count += 1;
     }

--- a/src/scan_validator.cpp
+++ b/src/scan_validator.cpp
@@ -20,7 +20,7 @@ laser_filters::ScanValidator::ScanValidator() :
 }
 
 laser_filters::ScanValidator::~ScanValidator()
-{ 
+{
 
 }
 

--- a/src/scan_validator.cpp
+++ b/src/scan_validator.cpp
@@ -69,7 +69,7 @@ bool laser_filters::ScanValidator::update(
   {
     // Zero range usually means obstacle is further than LIDAR max range
     // Zero intensity occurs when the ray reflects from reflective object or another LIDAR
-    if(input_scan.ranges[i] == 0 || input_scan.intensities[i] == 0)
+    if(input_scan.ranges[i] == 0 || input_scan.intensities[i] == 0 || std::isnan(input_scan.ranges[i]))
     {
       zero_count += 1;
       continue;

--- a/src/scan_validator.cpp
+++ b/src/scan_validator.cpp
@@ -30,7 +30,6 @@ bool laser_filters::ScanValidator::configure()
   getParam("lidar_occlusion_threshold", lidar_occlusion_threshold_);
   getParam("lidar_invalid_threshold", lidar_invalid_threshold_);
   getParam("contour_tolerance", contour_tolerance_);
-  getParam("frame_id", frame_id_);
   getParam("angle_min", angle_min_);
   getParam("angle_max", angle_max_);
   getParam("angle_increment", angle_increment_);

--- a/test/fake_laser.py
+++ b/test/fake_laser.py
@@ -5,7 +5,7 @@ import roslib; roslib.load_manifest(PKG)
 
 import rospy
 from sensor_msgs.msg import LaserScan
-from Numeric import ones
+from numpy import ones
 
 def laser_test():
     pub = rospy.Publisher('laser_scan', LaserScan)

--- a/test/test_scan_filter_chain.cpp
+++ b/test/test_scan_filter_chain.cpp
@@ -181,7 +181,6 @@ TEST(ScanToScanFilterChain, ArrayFilter)
     EXPECT_NEAR(msg_out.ranges[i],expected_msg.ranges[i],1e-3);
     EXPECT_NEAR(msg_out.intensities[i],msg_in.intensities[i],1e-3);
   }
-
   filter_chain_.clear();
 }
 
@@ -201,17 +200,13 @@ TEST(ScanToScanFilterChain, RadiusFilter)
 
   EXPECT_TRUE(filter_chain_.update(msg_in, msg_out));
   expect_ranges_eq(msg_out.ranges, expected_msg.ranges);
-  
-  //GTEST_COUT << "range validator\n";
-  //print_ranges(expected_msg.ranges);
-  //print_ranges(msg_out.ranges);
 
   // test cur_threshold is setup correctly and we consider euclidean distance rather than range only
   float temp2[] = {0.9, 0.8, 1.0, 1.0, 1.1, 9.0, 1.0, 1.0, 1.0, 2.3};
   std::vector<float> v2 (temp2, temp2 + sizeof(temp2) / sizeof(float));
   msg_in.ranges = v2;
   EXPECT_TRUE(filter_chain_.update(msg_in, msg_out));
-  
+
   float temp3[] = {nanval, nanval, nanval, 1.0, nanval, nanval, 1.0, 1.0, 1.0, nanval};
   std::vector<float> v3 (temp3, temp3 + sizeof(temp3) / sizeof(float));
   expected_msg.ranges = v3;
@@ -242,8 +237,7 @@ TEST(ScanToScanFilterChain, Validator)
 
   msg_in = gen_msg();
 
-
-//Test: passthrough
+  //Test: passthrough
   float temp[] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
   std::vector<float> v (temp, temp + sizeof(temp) / sizeof(float));
   expected_msg.ranges = v;
@@ -252,21 +246,17 @@ TEST(ScanToScanFilterChain, Validator)
   std::vector<float> v1 (temp1, temp1 + sizeof(temp1) / sizeof(float));
   msg_in.ranges = v1;
 
-
   EXPECT_TRUE(filter_chain_.update(msg_in, msg_out));
   expect_ranges_eq(msg_out.ranges, expected_msg.ranges);
 
-
-
-//Test: occlustion threshold. Many low values inside contour
+  //Test: occlustion threshold. Many low values inside contour
   float temp3[] = {0.4, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 1.0, 1.0};
   std::vector<float> v3 (temp3, temp3 + sizeof(temp3) / sizeof(float));
   msg_in.ranges = v3;
 
   EXPECT_FALSE(filter_chain_.update(msg_in, msg_out)) << "should fail due to occlusion threshold";
-  
 
-//Test: trigger invalid threshold
+  //Test: trigger invalid threshold
   float temp4[] = {nanval, nanval, nanval, nanval, nanval, nanval, nanval, nanval, 1.0, 1.0};
   std::vector<float> v4 (temp4, temp4 + sizeof(temp4) / sizeof(float));
   expected_msg.ranges = v4;
@@ -275,15 +265,11 @@ TEST(ScanToScanFilterChain, Validator)
   std::vector<float> v5 (temp5, temp5 + sizeof(temp5) / sizeof(float));
   msg_in.ranges = v5;
 
-
   EXPECT_TRUE(filter_chain_.update(msg_in, msg_out));
   expect_ranges_eq(msg_out.ranges, expected_msg.ranges);
   //TODO: expect log warning for invalid points
 
   filter_chain_.clear();
-
-
-
 }
 
 int main(int argc, char **argv){

--- a/test/test_scan_filter_chain.cpp
+++ b/test/test_scan_filter_chain.cpp
@@ -33,6 +33,7 @@
 #include "sensor_msgs/LaserScan.h"
 #include <pluginlib/class_loader.h>
 
+#define GTEST_COUT std::cerr
 
 sensor_msgs::LaserScan gen_msg(){
   sensor_msgs::LaserScan msg;
@@ -61,12 +62,23 @@ sensor_msgs::LaserScan gen_msg(){
 void expect_ranges_eq(const std::vector<float> &a, const std::vector<float> &b) {
   for( int i=0; i<10; i++) {
     if(std::isnan(a[i])) {
-      EXPECT_TRUE(std::isnan(a[i]));
+      EXPECT_TRUE(std::isnan(b[i]));
     }
     else {
       EXPECT_NEAR(a[i], b[i], 1e-6);
     }
   }
+}
+
+void print_ranges(const std::vector<float> &a) {
+  for(auto i = 0; i < a.size(); i++)
+  {
+    // Zero range usually means obstacle is further than LIDAR max range
+    // Zero intensity occurs when the ray reflects from reflective object or another LIDAR
+    // NAN values present when points rejected by a filter
+    GTEST_COUT << a[i] << " ";
+  }
+  GTEST_COUT << "\n";
 }
 
 TEST(ScanToScanFilterChain, BadConfiguration)
@@ -178,7 +190,7 @@ TEST(ScanToScanFilterChain, RadiusFilter)
   sensor_msgs::LaserScan msg_in, msg_out, expected_msg;
   // test basic functionality
   float nanval = std::numeric_limits<float>::quiet_NaN();
-  float temp[] = {1.0, nanval, 1.0, 1.0, 1.0, nanval, 1.0, 1.0, 1.0, nanval};
+  float temp[] = {nanval, nanval, 1.0, 1.0, 1.0, nanval, 1.0, 1.0, 1.0, nanval};
   std::vector<float> v1 (temp, temp + sizeof(temp) / sizeof(float));
   expected_msg.ranges = v1;
   filters::FilterChain<sensor_msgs::LaserScan> filter_chain_("sensor_msgs::LaserScan");
@@ -189,14 +201,18 @@ TEST(ScanToScanFilterChain, RadiusFilter)
 
   EXPECT_TRUE(filter_chain_.update(msg_in, msg_out));
   expect_ranges_eq(msg_out.ranges, expected_msg.ranges);
+  
+  //GTEST_COUT << "range validator\n";
+  //print_ranges(expected_msg.ranges);
+  //print_ranges(msg_out.ranges);
 
   // test cur_threshold is setup correctly and we consider euclidean distance rather than range only
   float temp2[] = {0.9, 0.8, 1.0, 1.0, 1.1, 9.0, 1.0, 1.0, 1.0, 2.3};
   std::vector<float> v2 (temp2, temp2 + sizeof(temp2) / sizeof(float));
   msg_in.ranges = v2;
   EXPECT_TRUE(filter_chain_.update(msg_in, msg_out));
-
-  float temp3[] = {nanval, nanval, 1.0, 1.0, 1.1, nanval, 1.0, 1.0, 1.0, nanval};
+  
+  float temp3[] = {nanval, nanval, nanval, 1.0, nanval, nanval, 1.0, 1.0, 1.0, nanval};
   std::vector<float> v3 (temp3, temp3 + sizeof(temp3) / sizeof(float));
   expected_msg.ranges = v3;
   expect_ranges_eq(msg_out.ranges, expected_msg.ranges);
@@ -207,12 +223,67 @@ TEST(ScanToScanFilterChain, RadiusFilter)
   msg_in.ranges = v4;
   EXPECT_TRUE(filter_chain_.update(msg_in, msg_out));
 
-  float temp5[] = {4.9, nanval, nanval, nanval, 8.0, nanval, nanval, 1.0, 1.0, nanval};
+  float temp5[] = {nanval, nanval, nanval, nanval, nanval, nanval, nanval, nanval, 1.0, nanval};
   std::vector<float> v5 (temp5, temp5 + sizeof(temp5) / sizeof(float));
   expected_msg.ranges = v5;
   expect_ranges_eq(msg_out.ranges, expected_msg.ranges);
 
   filter_chain_.clear();
+}
+
+TEST(ScanToScanFilterChain, Validator)
+{
+  sensor_msgs::LaserScan msg_in, msg_out, expected_msg;
+  // test basic functionality
+  float nanval = std::numeric_limits<float>::quiet_NaN();
+  filters::FilterChain<sensor_msgs::LaserScan> filter_chain_("sensor_msgs::LaserScan");
+
+  EXPECT_TRUE(filter_chain_.configure("validator_filter_chain"));
+
+  msg_in = gen_msg();
+
+
+//Test: passthrough
+  float temp[] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+  std::vector<float> v (temp, temp + sizeof(temp) / sizeof(float));
+  expected_msg.ranges = v;
+
+  float temp1[] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+  std::vector<float> v1 (temp1, temp1 + sizeof(temp1) / sizeof(float));
+  msg_in.ranges = v1;
+
+
+  EXPECT_TRUE(filter_chain_.update(msg_in, msg_out));
+  expect_ranges_eq(msg_out.ranges, expected_msg.ranges);
+
+
+
+//Test: occlustion threshold. Many low values inside contour
+  float temp3[] = {0.4, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 1.0, 1.0};
+  std::vector<float> v3 (temp3, temp3 + sizeof(temp3) / sizeof(float));
+  msg_in.ranges = v3;
+
+  EXPECT_FALSE(filter_chain_.update(msg_in, msg_out)) << "should fail due to occlusion threshold";
+  
+
+//Test: trigger invalid threshold
+  float temp4[] = {nanval, nanval, nanval, nanval, nanval, nanval, nanval, nanval, 1.0, 1.0};
+  std::vector<float> v4 (temp4, temp4 + sizeof(temp4) / sizeof(float));
+  expected_msg.ranges = v4;
+
+  float temp5[] = {nanval, nanval, nanval, nanval, nanval, nanval, nanval , nanval, 1.0, 1.0};
+  std::vector<float> v5 (temp5, temp5 + sizeof(temp5) / sizeof(float));
+  msg_in.ranges = v5;
+
+
+  EXPECT_TRUE(filter_chain_.update(msg_in, msg_out));
+  expect_ranges_eq(msg_out.ranges, expected_msg.ranges);
+  //TODO: expect log warning for invalid points
+
+  filter_chain_.clear();
+
+
+
 }
 
 int main(int argc, char **argv){

--- a/test/test_scan_filter_chain.yaml
+++ b/test/test_scan_filter_chain.yaml
@@ -50,3 +50,16 @@ radius_filter_chain:
       threshold_number: 2
       threshold_ratio: 0.1
 
+validator_filter_chain:
+- type: ScanValidator
+  name: scan_validator
+  params:
+    lidar_occlusion_threshold: 0.5
+    lidar_invalid_threshold: 0.7
+    contour_tolerance: 0.02
+    angle_min: -.5
+    angle_max: 0.5
+    angle_increment: 0.1
+    range_min: 0.5
+    range_max: 1.5
+    contour: [0.5, 0.5, 0.4, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]

--- a/test/test_scan_filter_chain.yaml
+++ b/test/test_scan_filter_chain.yaml
@@ -57,9 +57,9 @@ validator_filter_chain:
     lidar_occlusion_threshold: 0.5
     lidar_invalid_threshold: 0.7
     contour_tolerance: 0.02
-    angle_min: -.5
+    angle_min: -0.5
     angle_max: 0.5
     angle_increment: 0.1
     range_min: 0.5
     range_max: 1.5
-    contour: [0.5, 0.5, 0.4, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+    contour: [0.5, 0.2, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]


### PR DESCRIPTION
* Updated naming of thresholds. "zero threshold" is now "invalid threshold" because it now considers both zero and nan values.
* Added automated tests for scan validator
* fixed typo in test code expect_ranges_eq (test_scan_filter_chain.cpp) that was checking nan values incorrectly (test-only issue)
